### PR TITLE
Use query parameter to filter for active sprints

### DIFF
--- a/src/Clients/JiraClient.ts
+++ b/src/Clients/JiraClient.ts
@@ -36,9 +36,9 @@ export class JiraClient implements ITfsClient{
     const BaseURL = `https://${settings.jiraSettings.baseUrl}/rest/agile/1.0`;
 
     try {
-      const sprintsResponse = await requestUrl({ method: 'GET', headers: headers, url: `${BaseURL}/board/${settings.jiraSettings.boardId}/sprint` })
+      const sprintsResponse = await requestUrl({ method: 'GET', headers: headers, url: `${BaseURL}/board/${settings.jiraSettings.boardId}/sprint?state=active` })
 
-      const currentSprintId = sprintsResponse.json.values.filter((sprint:any) => sprint.state === 'active')[0].id;
+      const currentSprintId = sprintsResponse.json.values[0].id;
       
       const issuesResponse = await requestUrl({ method: 'GET', headers: headers, url: `${BaseURL}/board/${settings.jiraSettings.boardId}/sprint/${currentSprintId}/issue?jql=assignee=\"${settings.jiraSettings.name}\"` });
 


### PR DESCRIPTION
Hey there,

Thanks for making this plugin! It's always neat to see more plugins trying to bridge work content into Obsidian.

This PR streamlines filtering for a sprint by making use of the `state` query parameter that you can pass to the sprints API endpoint.

I'd also point out that, by default, that endpoint only returns 50 entries so to get beyond the initial 50 sprints, you need to make further requests although I don't expect having 50 active sprints to be reasonable (or even possible?)

Anyway, my workplace has more than 50 historical sprints and the endpoint doesn't guarantee any order. In fact, it appears to start from the oldest first so for anyone with more than 50 sprints, the plugin fails as filtering returns 0 results which the plugin will then try to retrieve the first entry, blowing up 😉 

Anyway, I'd be interested to know what else you might have on the roadmap for this plugin 🙂 It'd be neat to see two way syncing which I'd be happy to contribute towards.