### PR TITLE
[#4] [Feature Request] Add task "Assigned To" field

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,7 @@ export interface AgileTaskNotesSettings {
 const DEFAULT_SETTINGS: AgileTaskNotesSettings = {
   selectedTfsClient: 'AzureDevops',
   targetFolder: '',
-  noteTemplate: '# {{TASK_TITLE}}\n#{{TASK_TYPE}}\n\nLink: {{TASK_LINK}}\n\n#todo:\n- [ ] Create todo list\n- [ ] \n\n## Notes:\n',
+  noteTemplate: '# {{TASK_TITLE}}\n#{{TASK_TYPE}}\n\nid: {{TASK_ID}}\n\nstate: {{TASK_STATE}}\n\nAssignedTo: {{TASK_ASSIGNEDTO}}\n\nLink: {{TASK_LINK}}\n\n#todo:\n- [ ] Create todo list\n- [ ] \n\n## Notes:\n',
   intervalMinutes: 0,
   createKanban: true,
   azureDevopsSettings: AZURE_DEVOPS_DEFAULT_SETTINGS,
@@ -119,7 +119,7 @@ class AgileTaskNotesPluginSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
     .setName('Inital Task Content')
-    .setDesc('Set the inital content for each new task note. Available variables: {{TASK_TITLE}}, {{TASK_TYPE}}, {{TASK_LINK}}')
+    .setDesc('Set the inital content for each new task note. Available variables: {{TASK_ID}}, {{TASK_TITLE}}, {{TASK_TYPE}}, {{TASK_STATE}}, {{TASK_ASSIGNEDTO}}, {{TASK_LINK}}')
     .addTextArea(text => {
         text
             .setPlaceholder('Initial content in raw markdown format')

--- a/src/Clients/AzureDevopsClient.ts
+++ b/src/Clients/AzureDevopsClient.ts
@@ -60,7 +60,7 @@ export class AzureDevopsClient implements ITfsClient{
 
       let tasks:Array<Task> = [];
       tasksInCurrentSprint.forEach((task:any) => {
-        tasks.push(new Task(task.id, task.fields["System.State"], task.fields["System.Title"], task.fields["System.WorkItemType"], `https://${settings.azureDevopsSettings.instance}/${settings.azureDevopsSettings.collection}/${settings.azureDevopsSettings.project}/_workitems/edit/${task.id}`));
+        tasks.push(new Task(task.id, task.fields["System.State"], task.fields["System.Title"], task.fields["System.WorkItemType"], task.fields["System.AssignedTo"]["displayName"], `https://${settings.azureDevopsSettings.instance}/${settings.azureDevopsSettings.collection}/${settings.azureDevopsSettings.project}/_workitems/edit/${task.id}`));
       });
 
       // Create markdown files based on remote task in current sprint

--- a/src/Clients/JiraClient.ts
+++ b/src/Clients/JiraClient.ts
@@ -51,7 +51,7 @@ export class JiraClient implements ITfsClient{
 
       let tasks:Array<Task> = [];
       assignedIssuesInSprint.forEach((task:any) => {
-        tasks.push(new Task(task.key, task.fields["status"]["statusCategory"]["name"], task.fields["summary"], task.fields["issuetype"]["name"], `https://${settings.jiraSettings.baseUrl}/browse/${task.key}`));
+        tasks.push(new Task(task.key, task.fields["status"]["statusCategory"]["name"], task.fields["summary"], task.fields["issuetype"]["name"], task.fields["assignee"]["displayName"], `https://${settings.jiraSettings.baseUrl}/browse/${task.key}`));
       });
 
       // Create markdown files based on remote task in current sprint

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -8,13 +8,15 @@ export class Task {
   public state: string;
   public title: string;
   public type: string;
+  public assignedTo: string;
   public link: string;
 
-  constructor(id: string, state: string, title: string, type: string, link: string) {
+  constructor(id: string, state: string, title: string, type: string, assignedTo: string, link: string) {
     this.id = id;
     this.state = state;
     this.title = title;
-    this.type = type;
+    this.type = type;    
+    this.assignedTo = assignedTo;
     this.link = link;
   }
 }

--- a/src/VaultHelper.ts
+++ b/src/VaultHelper.ts
@@ -118,8 +118,11 @@ export class VaultHelper {
     const filepath = path + `/${filename}.md`;
 
     let content = template
+            .replace(/{{TASK_ID}}/g, task.id)
             .replace(/{{TASK_TITLE}}/g, task.title)
+            .replace(/{{TASK_STATE}}/g, task.state)
             .replace(/{{TASK_TYPE}}/g, task.type.replace(/ /g,''))
+            .replace(/{{TASK_ASSIGNEDTO}}/g, task.assignedTo)
             .replace(/{{TASK_LINK}}/g, task.link);
 
     return app.vault.create(filepath, content);


### PR DESCRIPTION
I have added AssignedTo to AzureDevOps and JIRA backend.

AzureDevOps has been tested successfully.
I don't have any JIRA access to test. The JIRA dev is based on JIRA documentation.

Additionnally, I have adding substitution patterns : {{TASK_ID}}, {{TASK_STATE}}, {{TASK_ASSIGNEDTO}}

My main usage is with DataView plugin and create some metadata for each task files.

I let you edit the version files and do the release management stuff.

Thanks a lot !