### PR TITLE
Alternative authmode

### DIFF
--- a/src/Clients/JiraClient.ts
+++ b/src/Clients/JiraClient.ts
@@ -118,6 +118,18 @@ export class JiraClient implements ITfsClient{
 				}));
 
     new Setting(container)
+      .setName('Authorization mode')
+      .setDesc('Set the mode of authorization to be used')
+      .addDropdown((dropdown) => {
+        dropdown.addOption("basic", "Basic Auth");
+        dropdown.addOption("bearer", "Personal Access Token");
+        dropdown.setValue("basic")
+          .onChange(async (value) => {
+            await plugin.saveSettings();
+          });
+      });
+
+    new Setting(container)
     .setName('API Token')
     .setDesc('The API token generated with your account')
     .addText(text => text

--- a/src/Clients/JiraClient.ts
+++ b/src/Clients/JiraClient.ts
@@ -30,19 +30,16 @@ export class JiraClient implements ITfsClient{
 
   public async updateCurrentSprint(settings: AgileTaskNotesSettings): Promise<void> {
 
-    const headers = {
+    var headers = {
       "Authorization": '',
       "Content-Type": "application/json"
     }
-    switch(settings.jiraSettings.authmode) {
-      case 'basic': {
+    if(settings.jiraSettings.authmode == 'basic') {
         const encoded64Key = Buffer.from(`${settings.jiraSettings.email}:${settings.jiraSettings.apiToken}`).toString("base64");
         headers.Authorization = `Basic ${encoded64Key}`
-      }
-      case 'bearer': {
+    } else if(settings.jiraSettings.authmode = 'bearer') {
         headers.Authorization = `Bearer ${settings.jiraSettings.apiToken}`
-      }
-    }
+    } 
 
     const BaseURL = `https://${settings.jiraSettings.baseUrl}/rest/agile/1.0`;
 

--- a/src/Clients/JiraClient.ts
+++ b/src/Clients/JiraClient.ts
@@ -35,11 +35,13 @@ export class JiraClient implements ITfsClient{
       "Content-Type": "application/json"
     }
     switch(settings.jiraSettings.authmode) {
-      case 'basic':
+      case 'basic': {
         const encoded64Key = Buffer.from(`${settings.jiraSettings.email}:${settings.jiraSettings.apiToken}`).toString("base64");
         headers.Authorization = `Basic ${encoded64Key}`
-      case 'bearer':
+      }
+      case 'bearer': {
         headers.Authorization = `Bearer ${settings.jiraSettings.apiToken}`
+      }
     }
 
     const BaseURL = `https://${settings.jiraSettings.baseUrl}/rest/agile/1.0`;


### PR DESCRIPTION
Self-hosted jira instances (or at least the one I am developing against) do not seem to support the basic auth method that was used by this plugin as of now. I have added a toggle to twitch to personal access token auth. The diff looks a little strange because I have uniformly formatted the settings, but I have not intentionally made any other changes :) 

See more about PATs for jira here: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

PS: This is a prerequisite for #7 which I am currently working on.